### PR TITLE
add QuickInformedRRT*

### DIFF
--- a/src/core/global_planner/sample_planner/CMakeLists.txt
+++ b/src/core/global_planner/sample_planner/CMakeLists.txt
@@ -1,6 +1,13 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(sample_planner)
 
+find_package(OpenMP)
+if (OPENMP_FOUND)
+  set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}") 
+  set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}") 
+  set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}") 
+endif()
+
 find_package(catkin REQUIRED COMPONENTS
   angles
   roscpp
@@ -34,6 +41,7 @@ add_library(${PROJECT_NAME}
   src/rrt_star.cpp
   src/rrt_connect.cpp
   src/informed_rrt.cpp
+  src/quick_informed_rrt.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/src/core/global_planner/sample_planner/include/quick_informed_rrt.h
+++ b/src/core/global_planner/sample_planner/include/quick_informed_rrt.h
@@ -1,0 +1,73 @@
+/**
+ * *********************************************************
+ *
+ * @file: quick_informed_rrt.h
+ * @brief: Contains the quick informed RRT* planner class
+ * @author: Honbo He
+ * @date: 2024-06-05
+ * @version: 0.9
+ *
+ * Copyright (c) 2024, Yang Haodong.
+ * All rights reserved.
+ *
+ * --------------------------------------------------------
+ *
+ * ********************************************************
+ */
+#ifndef QUICK_INFORMED_RRT_H
+#define QUICK_INFORMED_RRT_H
+
+#include "informed_rrt.h"
+
+namespace global_planner
+{
+/**
+ * @brief Class for objects that plan using the Informed RRT* algorithm
+ */
+class QuickInformedRRT : public InformedRRT
+{
+public:
+  /**
+   * @brief  Constructor
+   * @param   costmap   the environment for path planning
+   * @param   sample_num  andom sample points
+   * @param   max_dist    max distance between sample points
+   * @param   r           optimization radius
+   */
+  QuickInformedRRT(costmap_2d::Costmap2D* costmap, int sample_num, double max_dist, double r, double r_set, int n_threads, double d_extend, double t_freedom);
+
+  /**
+   * @brief RRT implementation
+   * @param start     start node
+   * @param goal      goal node
+   * @param expand    containing the node been search during the process
+   * @return tuple contatining a bool as to whether a path was found, and the path
+   */
+  bool plan(const Node& start, const Node& goal, std::vector<Node>& path, std::vector<Node>& expand);
+
+protected:
+  /**
+   * @brief Generates a random node
+   * @return Generated node
+   * @param mu
+   * @param path
+   */
+  Node _generateRandomNode(int mu, std::vector<Node> path);
+
+  /**
+   * @brief Regular the new node by the nearest node in the sample list
+   * @param list     sample list
+   * @param node     sample node
+   * @return nearest node
+   */
+  Node _findNearestPoint(std::unordered_map<int, Node> list, Node& node);
+
+protected:
+  double set_r_;             // radius of priority circles set
+  int rewire_threads_;       // parallel rewire process
+  double step_extend_d_;     // increased distance of adaptive extend step size
+  double recover_max_dist_;  // recover value of max_dist_ when met obstacle
+  double t_distr_freedom_;   // freedom of t distribution
+};
+}  // namespace global_planner
+#endif

--- a/src/core/global_planner/sample_planner/include/rrt.h
+++ b/src/core/global_planner/sample_planner/include/rrt.h
@@ -79,6 +79,7 @@ protected:
   std::unordered_map<int, Node> sample_list_;  // set of sample nodes
   int sample_num_;                             // max sample number
   double max_dist_;                            // max distance threshold
+  double opti_sample_p_ = 0.05;                // optimized sample probability, default to 0.05
 };
 }  // namespace global_planner
 #endif  // RRT_H

--- a/src/core/global_planner/sample_planner/include/sample_planner.h
+++ b/src/core/global_planner/sample_planner/include/sample_planner.h
@@ -134,6 +134,10 @@ private:
   int sample_points_;    // random sample points
   double sample_max_d_;  // max distance between sample points
   double opt_r_;         // optimization raidus
+  double prior_set_r_;   // radius of priority sample circles
+  int rewire_threads_n_; // threads number of rewire process
+  double step_ext_d_;    // increased distance of adaptive extend step size
+  double t_freedom_;     // freedom of t distribution
 };
 }  // namespace sample_planner
 #endif

--- a/src/core/global_planner/sample_planner/src/quick_informed_rrt.cpp
+++ b/src/core/global_planner/sample_planner/src/quick_informed_rrt.cpp
@@ -113,7 +113,7 @@ bool QuickInformedRRT::plan(const Node& start, const Node& goal, std::vector<Nod
     else // if do not update, decrease mu termly
     {
       mu_cnt ++;
-      if(mu_cnt * 100 == 0)
+      if(mu_cnt % 100 == 0)
         mu = std::fmax(0, mu - 0.5);
     }
   }

--- a/src/core/global_planner/sample_planner/src/quick_informed_rrt.cpp
+++ b/src/core/global_planner/sample_planner/src/quick_informed_rrt.cpp
@@ -1,0 +1,270 @@
+/**
+ * *********************************************************
+ *
+ * @file: quick_informed_rrt.cpp
+ * @brief: Contains the quick informed RRT* planner class
+ * @author: Honbo He
+ * @date: 2024-06-05
+ * @version: 0.9
+ *
+ * Copyright (c) 2024, Yang Haodong.
+ * All rights reserved.
+ *
+ * --------------------------------------------------------
+ *
+ * ********************************************************
+ */
+#include <cmath>
+#include <random>
+#include <omp.h>
+#include "quick_informed_rrt.h"
+
+namespace global_planner
+{
+/**
+ * @brief  Constructor
+ * @param   costmap   the environment for path planning
+ * @param   max_dist    max distance between sample points
+ */
+QuickInformedRRT::QuickInformedRRT(costmap_2d::Costmap2D* costmap, int sample_num, double max_dist, double r, double r_set, int n_threads, double d_extend, double t_freedom)
+  : InformedRRT(costmap, sample_num, max_dist, r)
+{
+  set_r_ = r_set;
+  rewire_threads_   = n_threads;
+  step_extend_d_    = d_extend;
+  recover_max_dist_ = max_dist;
+  t_distr_freedom_  = t_freedom;
+}
+
+/**
+ * @brief Informed RRT* implementation
+ * @param start     start node
+ * @param goal      goal node
+ * @param expand    containing the node been search during the process
+ * @return tuple contatining a bool as to whether a path was found, and the path
+ */
+bool QuickInformedRRT::plan(const Node& start, const Node& goal, std::vector<Node>& path, std::vector<Node>& expand)
+{
+  // initialization
+  c_best_ = std::numeric_limits<double>::max();
+  c_min_ = helper::dist(start, goal);
+  int best_parent = -1;
+  sample_list_.clear();
+  // copy
+  start_ = start, goal_ = goal;
+  sample_list_.insert(std::make_pair(start.id_, start));
+  expand.push_back(start);
+  // adaptive sampling bias
+  double dist_s2g = helper::dist(start, goal);
+  double dist_m2g = dist_s2g * 0.95;
+  // priority circles set
+  double mu = 0.0;
+  int mu_cnt = 0;
+
+  // main loop
+  int iteration = 0;
+  while (iteration < sample_num_)
+  {
+    iteration++;
+
+    // update probability of sampling bias
+    opti_sample_p_ = std::min(0.75, 1 - dist_m2g/dist_s2g);
+
+    // generate a random node in the map
+    Node sample_node = _generateRandomNode(mu, path);
+
+    // obstacle
+    if (costmap_->getCharMap()[sample_node.id_] >= costmap_2d::LETHAL_OBSTACLE * factor_)
+      continue;
+
+    // visited
+    if (sample_list_.find(sample_node.id_) != sample_list_.end())
+      continue;
+
+    // regular the sample node
+    Node new_node = _findNearestPoint(sample_list_, sample_node);
+    if (new_node.id_ == -1)
+      continue;
+    else
+    {
+      sample_list_.insert(std::make_pair(new_node.id_, new_node));
+      expand.push_back(new_node);
+    }
+
+    auto dist_ = helper::dist(new_node, goal_);
+    // update min dist from tree to goal
+    if (dist_ < dist_m2g) dist_m2g = dist_;
+    // goal found
+    if (dist_ <= max_dist_ && !_isAnyObstacleInPath(new_node, goal_))
+    {
+      double cost = dist_ + new_node.g_;
+      if (cost < c_best_)
+      {
+        best_parent = new_node.id_;
+        c_best_ = cost;
+        // update path
+        Node goal_star(goal_.x_, goal_.y_, c_best_, 0, grid2Index(goal_.x_, goal_.y_), best_parent);
+        sample_list_.insert(std::make_pair(goal_star.id_, goal_star));
+        path = _convertClosedListToPath(sample_list_, start, goal);
+        sample_list_.erase(goal_star.id_);
+        mu = std::fmin(5, mu + 0.5);
+      }
+    }
+    else // if do not update, decrease mu termly
+    {
+      mu_cnt ++;
+      if(mu_cnt * 100 == 0)
+        mu = std::fmax(0, mu - 0.5);
+    }
+  }
+
+  if (best_parent != -1)
+  {
+    Node goal_star(goal_.x_, goal_.y_, c_best_, 0, grid2Index(goal_.x_, goal_.y_), best_parent);
+    sample_list_.insert(std::make_pair(goal_star.id_, goal_star));
+
+    path = _convertClosedListToPath(sample_list_, start, goal);
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * @brief Generates a random node
+ * @return Generated node
+ */
+Node QuickInformedRRT::_generateRandomNode(int mu, std::vector<Node> path)
+{
+  std::random_device rd;
+  std::mt19937 eng(rd());
+  std::student_t_distribution<> t_distr(t_distr_freedom_);
+
+  if(std::abs(t_distr(eng)) < mu && path.size() != 0) // sample in priority circles
+  {
+      int wc = rand() % path.size();
+      std::uniform_real_distribution<float> p(-set_r_, set_r_);
+      int cx = path[wc].x_ + p(eng);
+      int cy = path[wc].y_ + p(eng);
+      return Node(cx, cy, 0, 0, grid2Index(cx, cy), 0);
+  }
+  else // ellipse sample
+  {
+    if (c_best_ < std::numeric_limits<double>::max())
+    {
+      while (true)
+      {
+        // unit ball sample
+        double x, y;
+        std::uniform_real_distribution<float> p(-1, 1);
+        while (true)
+        {
+            x = p(eng);
+            y = p(eng);
+            if (x * x + y * y < 1)
+            break;
+        }
+        // transform to ellipse
+        Node temp = _transform(x, y);
+        if (temp.id_ < map_size_ - 1)
+            return temp;
+      }
+    }
+    else
+      return RRTStar::_generateRandomNode();
+  }
+}
+
+/**
+ * @brief Regular the new node by the nearest node in the sample list
+ * @param list     sample list
+ * @param node     sample node
+ * @return nearest node
+ */
+Node QuickInformedRRT::_findNearestPoint(std::unordered_map<int, Node> list, Node& node)
+{
+  Node nearest_node, new_node(node);
+  double min_dist = std::numeric_limits<double>::max();
+
+  for (const auto p : list)
+  {
+    // calculate distance
+    double new_dist = helper::dist(p.second, new_node);
+
+    // update nearest node
+    if (new_dist < min_dist)
+    {
+      nearest_node = p.second;
+      new_node.pid_ = nearest_node.id_;
+      new_node.g_ = new_dist + p.second.g_;
+      min_dist = new_dist;
+    }
+  }
+
+  // distance longer than the threshold
+  if (min_dist > max_dist_)
+  {
+    // connect sample node and nearest node, then move the nearest node
+    // forward to sample node with `max_distance` as result
+    double theta = helper::angle(nearest_node, new_node);
+    new_node.x_ = nearest_node.x_ + (int)(max_dist_ * cos(theta));
+    new_node.y_ = nearest_node.y_ + (int)(max_dist_ * sin(theta));
+    new_node.id_ = grid2Index(new_node.x_, new_node.y_);
+    new_node.g_ = max_dist_ + nearest_node.g_;
+  }
+
+  // obstacle check
+  if (!_isAnyObstacleInPath(new_node, nearest_node))
+  {
+    max_dist_ += step_extend_d_;
+
+    // parallel rewire optimization
+    std::vector<int> v_iters;
+    for (auto p : sample_list_) {
+      v_iters.push_back(p.first);
+    }
+
+#   pragma omp parallel for num_threads(rewire_threads_)
+    for (int i = 0; i < v_iters.size(); i++)
+    {
+      auto &p = sample_list_[v_iters[i]];
+      // inside the optimization circle
+      double new_dist = helper::dist(p, new_node);
+      if (new_dist > r_) continue;
+      
+      double cost = p.g_ + new_dist;
+      // update new sample node's cost and parent
+      if (new_node.g_ > cost)
+      {
+        if (!_isAnyObstacleInPath(new_node, p))
+        {
+          // other thread may update new_node.g_ 
+#         pragma omp critical
+          if (new_node.g_ > cost)
+          {
+            new_node.pid_ = p.id_;
+            new_node.g_ = cost;
+          }
+        }
+      }
+      else
+      {
+        // update nodes' cost inside the radius
+        cost = new_node.g_ + new_dist;
+        if (cost < p.g_)
+          if (!_isAnyObstacleInPath(new_node, p))
+          {
+            p.pid_ = new_node.id_;
+            p.g_ = cost;
+          }
+      }
+    }
+  }
+  else
+  {
+    max_dist_ = recover_max_dist_;
+    new_node.id_ = -1;
+  }
+  return new_node;
+}
+}  // namespace global_planner

--- a/src/core/global_planner/sample_planner/src/rrt.cpp
+++ b/src/core/global_planner/sample_planner/src/rrt.cpp
@@ -101,7 +101,7 @@ Node RRT::_generateRandomNode()
   // define the range
   std::uniform_real_distribution<float> p(0, 1);
   // heuristic
-  if (p(eng) > 0.05)
+  if (p(eng) > opti_sample_p_)
   {
     // generate node
     std::uniform_int_distribution<int> distr(0, map_size_ - 1);

--- a/src/core/global_planner/sample_planner/src/sample_planner.cpp
+++ b/src/core/global_planner/sample_planner/src/sample_planner.cpp
@@ -22,6 +22,7 @@
 #include "rrt_star.h"
 #include "rrt_connect.h"
 #include "informed_rrt.h"
+#include "quick_informed_rrt.h"
 
 PLUGINLIB_EXPORT_CLASS(sample_planner::SamplePlanner, nav_core::BaseGlobalPlanner)
 
@@ -76,6 +77,10 @@ void SamplePlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
     private_nh.param("sample_points", sample_points_, 500);  // random sample points
     private_nh.param("sample_max_d", sample_max_d_, 5.0);    // max distance between sample points
     private_nh.param("optimization_r", opt_r_, 10.0);        // optimization radius
+    private_nh.param("prior_sample_set_r", prior_set_r_, 10.0);   // radius of priority circles set
+    private_nh.param("rewire_threads_num", rewire_threads_n_, 2); // threads number of rewire process
+    private_nh.param("step_extend_d", step_ext_d_, 5.0);     // threads number of rewire process
+    private_nh.param("t_distr_freedom", t_freedom_, 1.0);    // freedom of t distribution
 
     // planner name
     std::string planner_name;
@@ -88,6 +93,8 @@ void SamplePlanner::initialize(std::string name, costmap_2d::Costmap2D* costmap,
       g_planner_ = std::make_shared<global_planner::RRTConnect>(costmap, sample_points_, sample_max_d_);
     else if (planner_name == "informed_rrt")
       g_planner_ = std::make_shared<global_planner::InformedRRT>(costmap, sample_points_, sample_max_d_, opt_r_);
+    else if (planner_name == "quick_informed_rrt")
+      g_planner_ = std::make_shared<global_planner::QuickInformedRRT>(costmap, sample_points_, sample_max_d_, opt_r_, prior_set_r_, rewire_threads_n_, step_ext_d_, t_freedom_);
 
     // pass costmap information to planner (required)
     g_planner_->setFactor(factor_);

--- a/src/sim_env/config/planner/sample_planner_params.yaml
+++ b/src/sim_env/config/planner/sample_planner_params.yaml
@@ -15,3 +15,12 @@ SamplePlanner:
   obstacle_factor: 0.5
   # whether publish expand zone or not
   expand_zone: true
+  # qi-rrt*:
+  # radius of priority circles set
+  prior_circle_set_r: 15.0
+  # increased distance of adaptive extend step size
+  step_extend_d: 30.0 # suggest between half and one times sample_max_d
+  # parallel rewire process
+  rewire_threads_num: 4
+  # aggressive or gradual optimizing strategy
+  t_distr_freedom: 1.0 # suggest from 0.2 to 3

--- a/src/sim_env/launch/include/navigation/move_base.launch.xml
+++ b/src/sim_env/launch/include/navigation/move_base.launch.xml
@@ -77,16 +77,19 @@
             if="$(eval arg('global_planner')=='rrt'
                     or arg('global_planner')=='rrt_star'
                     or arg('global_planner')=='informed_rrt'
+                    or arg('global_planner')=='quick_informed_rrt'
                     or arg('global_planner')=='rrt_connect')" />
         <param name="SamplePlanner/planner_name" value="$(arg global_planner)"
             if="$(eval arg('global_planner')=='rrt'
                     or arg('global_planner')=='rrt_star'
                     or arg('global_planner')=='informed_rrt'
+                    or arg('global_planner')=='quick_informed_rrt'
                     or arg('global_planner')=='rrt_connect')" />
         <rosparam file="$(find sim_env)/config/planner/sample_planner_params.yaml" command="load"
             if="$(eval arg('global_planner')=='rrt'
                     or arg('global_planner')=='rrt_star'
                     or arg('global_planner')=='informed_rrt'
+                    or arg('global_planner')=='quick_informed_rrt'
                     or arg('global_planner')=='rrt_connect')" />
 
         <!-- evolutionary search -->


### PR DESCRIPTION
Added the following items :
1. adaptive sampling bias strategy
2. priority sampling circle set based on the path obtained from each update
3. parallel rewiring process
4. adaptive step size expansion

How to use it :
We provide the following four options :
`prior_circle_set_r` : suggest 5.0 to 15.0
In the figure below, blue circles C1~C7 are sampled first, and this value controls the radius of the circle
<img src="https://github.com/ai-winter/ros_motion_planning/assets/78713753/5c99def6-dabc-40c8-9aa4-723f5b1b4351" alt="set" width="500"/>
`step_extend_d` : increased distance of adaptive extend step size, we suggest the value between half and one times sample_max_d.
`rewire_threads_num` : number of threads used to accelerate rewire process
`t_distr_freedom` : choose your algorithm more aggressive or conservative in optimizing. If the value is relatively small, the algorithm will be more conservative and exploratory, but at the same time, the degree of optimization may decrease.