### PR TITLE
fix target dir of mpc_controller object file

### DIFF
--- a/src/core/controller/mpc_controller/CMakeLists.txt
+++ b/src/core/controller/mpc_controller/CMakeLists.txt
@@ -44,3 +44,9 @@ target_link_libraries(${PROJECT_NAME}
   ${catkin_LIBRARIES}
   ${CONAN_LIBS}
 )
+
+# add custom target to copy libmpc_controller.so from build to devel dir.
+add_custom_command(
+  TARGET ${PROJECT_NAME} POST_BUILD
+  COMMAND ${CMAKE_COMMAND} -E copy $<TARGET_FILE:${PROJECT_NAME}> ${CATKIN_DEVEL_PREFIX}/lib/
+)


### PR DESCRIPTION
hi, ai-winter.

I found that the following issue can be solved with this pull request.
https://github.com/ai-winter/ros_motion_planning/issues/65

The problem happened because the shared object file is generated in "build", not in "devel/lib".
I suppose that this is because of the conan settings on mpc_controller package.
I added a few lines to copy the object file to the correct location.

please confirm whether it works on your environment.

best regards,
Shotaro Kojima