### PR TITLE
fix static_controller loading failure

### DIFF
--- a/src/core/controller/static_controller/static_controller_plugin.xml
+++ b/src/core/controller/static_controller/static_controller_plugin.xml
@@ -1,5 +1,5 @@
 <library path="lib/libstatic_controller">
-    <class name="static_controller/StaticController" type="static_controller::StaticController"
+    <class name="static_controller/StaticController" type="rmp::controller::StaticController"
         base_class_type="nav_core::BaseLocalPlanner">
         <description>
             A implementation of a local Static controller.


### PR DESCRIPTION
When setting `robot1_local_planner: static` in `user_config.yaml`, the `move_base` crashes with:

![image](https://github.com/user-attachments/assets/c58ab649-41a4-43d6-9c87-96600f36d4e9)

Correct the `type` of `static_controller`  in `static_controller_plugin.xml`  to fix this issue.

